### PR TITLE
Added `CavityParams`

### DIFF
--- a/src/Beamlines.jl
+++ b/src/Beamlines.jl
@@ -10,6 +10,7 @@ export MattStandard,
        AlignmentParams,
        PatchParams,
        BendParams,
+       CavityParams,
        BMultipole,
        Drift,
        Solenoid,
@@ -61,6 +62,7 @@ import GTPSA: sincu, sinhcu
 include("element.jl")
 include("beamline.jl")
 include("multipole.jl")
+include("cavity.jl")
 include("virtual.jl")
 include("bend.jl")
 include("control.jl")

--- a/src/cavity.jl
+++ b/src/cavity.jl
@@ -1,0 +1,109 @@
+@kwdef mutable struct CavityParams{T<:Number} <: AbstractParams
+    frequency::T          = Float32(0.0) # RF frequency in Hz or Harmonic number
+    voltage::T            = Float32(0.0) # Voltage in V 
+    phi0::T               = Float32(0.0) # Phase at reference energy
+    const harmon_master::Bool            # false = frequency in Hz, true = harmonic number
+
+    function CavityParams(args...)
+        return new{promote_type(map(x->typeof(x),args)...)}(args...)
+    end
+end
+
+Base.eltype(::CavityParams{T}) where {T} = T
+Base.eltype(::Type{CavityParams{T}}) where {T} = T
+isconst(::CavityParams, key::Symbol) = key == :harmon_master
+
+
+function Base.isapprox(a::CavityParams, b::CavityParams) 
+    return  a.frequency     ≈  b.frequency && 
+            a.voltage       ≈  b.voltage && 
+            a.phi0          ≈  b.phi0 && 
+            a.harmon_master == b.harmon_master
+end
+
+# Frequency mapping system analogous to BMULTIPOLE_STRENGTH_MAP
+const CAVITY_FREQUENCY_MAP = Dict{Symbol,Bool}(
+  :rf_frequency    => false,  # harmon_master = false (frequency in Hz)
+  :harmonic_number => true,   # harmon_master = true (harmonic number)
+)
+
+const CAVITY_FREQUENCY_INVERSE_MAP = Dict(value => key for (key, value) in CAVITY_FREQUENCY_MAP)
+
+function Base.hasproperty(c::CavityParams, key::Symbol)
+  if key in fieldnames(CavityParams)
+    return true
+  elseif haskey(CAVITY_FREQUENCY_MAP, key)
+    harmon_master = CAVITY_FREQUENCY_MAP[key]
+    return harmon_master == c.harmon_master
+  else
+    return false
+  end
+end
+
+function Base.getproperty(c::CavityParams, key::Symbol)
+  if key in fieldnames(CavityParams)
+    return getfield(c, key)
+  elseif haskey(CAVITY_FREQUENCY_MAP, key)
+    harmon_master = CAVITY_FREQUENCY_MAP[key]
+    if harmon_master == c.harmon_master
+      return c.frequency
+    else
+      correctkey = CAVITY_FREQUENCY_INVERSE_MAP[c.harmon_master]
+      error("Only $correctkey is currently set in CavityParams, $key cannot be calculated without particle species information")
+    end
+  end
+  error("CavityParams $c does not have property $key")
+end
+
+function Base.setproperty!(c::CavityParams{T}, key::Symbol, value) where {T}
+  if key in (:frequency, :voltage, :phi0)
+    return setfield!(c, key, T(value))
+  elseif key in fieldnames(CavityParams)
+    return setfield!(c, key, value)
+  elseif haskey(CAVITY_FREQUENCY_MAP, key)
+    harmon_master = CAVITY_FREQUENCY_MAP[key]
+    if harmon_master == c.harmon_master
+      return setfield!(c, :frequency, T(value))
+    else
+      error("CavityParams $c does not have property $key")
+    end
+  end
+  error("CavityParams $c does not have property $key")
+end
+
+function _setproperty!(pdict::ParamDict, p::CavityParams, key::Symbol, value)
+  if hasproperty(p, key) # Check if we can put this value in current struct
+    T = typeof(getproperty(p, key))
+    if promote_type(typeof(value), T) == T
+      if key != :harmon_master # Check if we need to create a new struct
+        return setproperty!(p, key, value)
+      else
+        return pdict[PROPERTIES_MAP[key]] = replace(p, key, value)
+      end
+    end
+  end
+  return pdict[PROPERTIES_MAP[key]] = replace(p, key, value)
+end
+
+
+function replace(c1::CavityParams{S}, key::Symbol, value) where {S}
+  T = promote_type(S, typeof(value))
+  
+  if haskey(CAVITY_FREQUENCY_MAP, key)
+    harmon_master = CAVITY_FREQUENCY_MAP[key]
+    # Create new CavityParams with updated harmon_master and frequency using inner constructor
+    return CavityParams(T(value), T(c1.voltage), T(c1.phi0), harmon_master)
+  elseif key == :harmon_master
+    # Handle direct harmon_master changes using inner constructor
+    return CavityParams(T(c1.frequency), T(c1.voltage), T(c1.phi0), value)
+  else
+    # Use copy constructor and setproperty! for regular properties
+    c1 = CavityParams(T(c1.frequency), T(c1.voltage), T(c1.phi0), c1.harmon_master)
+    setproperty!(c1, key, T(value))
+    return c1
+  end
+end
+
+# Note that it is currently impossible to derive harmonic number from frequency
+# or vice versa without knowing the particle species, so the virtual getter
+# function throws an error for the unspecified property.

--- a/src/keymaps.jl
+++ b/src/keymaps.jl
@@ -53,6 +53,11 @@ const PROPERTIES_MAP = Dict{Symbol,Type{<:AbstractParams}}(
   :dx_rot => PatchParams,
   :dy_rot => PatchParams,
   :dz_rot => PatchParams,
+
+  :frequency => CavityParams,
+  :voltage => CavityParams,
+  :phi0 => CavityParams,
+  :harmon_master => CavityParams,
 )
 
 const PARAMS_MAP = Dict{Symbol,Type{<:AbstractParams}}(
@@ -62,6 +67,7 @@ const PARAMS_MAP = Dict{Symbol,Type{<:AbstractParams}}(
   :BendParams => BendParams,
   :AlignmentParams => AlignmentParams,
   :PatchParams => PatchParams,
+  :CavityParams => CavityParams,
 )
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -514,4 +514,31 @@ using Test
     @test d.name == "d"
     @test d.L == 1+0.36
     @test a == 1+0.36
+
+    # CavityParams tests
+    # Basic RF frequency mode
+    cav = RFCavity(frequency=352e6, voltage=1e6, harmon_master=false)
+    @test cav.rf_frequency == 352e6 && cav.harmon_master == false
+    @test_throws ErrorException cav.harmonic_number
+    cav.rf_frequency = 500e6 + 1e3im
+    @test eltype(cav.CavityParams) == ComplexF64
+
+    # Harmonic number mode and mode switching
+    cav2 = RFCavity(harmonic_number=1160)
+    cav2.voltage = 200e6
+    @test cav2.harmonic_number == 1160 && cav2.harmon_master == true
+    @test_throws ErrorException cav2.rf_frequency
+    cav2.rf_frequency = 352e6  # Switch modes
+    @test cav2.rf_frequency == 352e6 && cav2.harmon_master == false
+
+    # Direct property access and CavityParams struct operations
+    cp = CavityParams(frequency=352e6, harmon_master=false)
+    @test hasproperty(cp, :rf_frequency) && !hasproperty(cp, :harmonic_number)
+    @test_throws ErrorException cp.harmonic_number
+    cav2.CavityParams = cp
+    @test cav2.CavityParams === cp
+
+    # Type promotion via replace function
+    cp_new = Beamlines.replace(CavityParams(frequency=352f6, harmon_master=false), :harmonic_number, 1160e0)
+    @test cp_new.harmon_master == true && eltype(cp_new) == Float64
 end


### PR DESCRIPTION
1. Added `CavityParams` struct
2. Added virtual properties `rf_frequency` and `harmonic_number` 
3. Included tests

Note that we do not have access to bunch species in Beamlines, so it is currently impossible to get `rf_frequency` if `harmon_master=T` or get `harmonic_number` if `harmon_master=F`

Also, is the name `harmonic_number` good? I could go with `harmon` or just `h`, but `harmonic_number` is most descriptive